### PR TITLE
Add ERC-20 and ERC-721 examples in a new Applications section

### DIFF
--- a/example_code/applications/erc20/Cargo.toml
+++ b/example_code/applications/erc20/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "stylus-erc20"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+stylus-sdk = "0.5.0"
+mini-alloc = "0.4.2"
+alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
+
+[features]
+export-abi = ["stylus-sdk/export-abi"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[profile.release]
+codegen-units = 1
+strip = true
+lto = true
+panic = "abort"
+opt-level = "s"

--- a/example_code/applications/erc20/src/erc20.rs
+++ b/example_code/applications/erc20/src/erc20.rs
@@ -161,26 +161,20 @@ impl<T: Erc20Params> Erc20<T> {
         T::DECIMALS
     }
 
+    /// Total supply of tokens
+    pub fn total_supply(&self) -> U256 {
+        self.total_supply.get()
+    }
+
     /// Balance of `address`
-    pub fn balance_of(&self, address: Address) -> U256 {
-        self.balances.get(address)
+    pub fn balance_of(&self, owner: Address) -> U256 {
+        self.balances.get(owner)
     }
 
     /// Transfers `value` tokens from msg::sender() to `to`
     pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
         self._transfer(msg::sender(), to, value)?;
         Ok(true)
-    }
-
-    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
-    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
-        self.allowances.setter(msg::sender()).insert(spender, value);
-        evm::log(Approval {
-            owner: msg::sender(),
-            spender,
-            value,
-        });
-        true
     }
 
     /// Transfers `value` tokens from `from` to `to`
@@ -211,6 +205,17 @@ impl<T: Erc20Params> Erc20<T> {
         self._transfer(from, to, value)?;
 
         Ok(true)
+    }
+
+    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
+    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
+        self.allowances.setter(msg::sender()).insert(spender, value);
+        evm::log(Approval {
+            owner: msg::sender(),
+            spender,
+            value,
+        });
+        true
     }
 
     /// Returns the allowance of `spender` on `owner`'s tokens

--- a/example_code/applications/erc20/src/erc20.rs
+++ b/example_code/applications/erc20/src/erc20.rs
@@ -1,0 +1,220 @@
+//! Implementation of the ERC-20 standard
+//!
+//! The eponymous [`Erc20`] type provides all the standard methods,
+//! and is intended to be inherited by other contract types.
+//!
+//! You can configure the behavior of [`Erc20`] via the [`Erc20Params`] trait,
+//! which allows specifying the name, symbol, and decimals of the token.
+//!
+//! Note that this code is unaudited and not fit for production use.
+
+// Imported packages
+use alloc::string::String;
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::sol;
+use core::marker::PhantomData;
+use stylus_sdk::{
+    evm,
+    msg,
+    prelude::*,
+};
+
+pub trait Erc20Params {
+    /// Immutable token name
+    const NAME: &'static str;
+
+    /// Immutable token symbol
+    const SYMBOL: &'static str;
+
+    /// Immutable token decimals
+    const DECIMALS: u8;
+}
+
+sol_storage! {
+    /// Erc20 implements all ERC-20 methods.
+    pub struct Erc20<T> {
+        /// Maps users to balances
+        mapping(address => uint256) balances;
+        /// Maps users to a mapping of each spender's allowance
+        mapping(address => mapping(address => uint256)) allowances;
+        /// The total supply of the token
+        uint256 total_supply;
+        /// Used to allow [`Erc20Params`]
+        PhantomData<T> phantom;
+    }
+}
+
+// Declare events and Solidity error types
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error InsufficientBalance(address from, uint256 have, uint256 want);
+    error InsufficientAllowance(address owner, address spender, uint256 have, uint256 want);
+}
+
+/// Represents the ways methods may fail.
+#[derive(SolidityError)]
+pub enum Erc20Error {
+    InsufficientBalance(InsufficientBalance),
+    InsufficientAllowance(InsufficientAllowance),
+}
+
+// These methods aren't exposed to other contracts
+// Methods marked as "pub" here are usable outside of the erc20 module (i.e. they're callable from lib.rs)
+// Note: modifying storage will become much prettier soon
+impl<T: Erc20Params> Erc20<T> {
+    /// Movement of funds between 2 accounts
+    /// (invoked by the external transfer() and transfer_from() functions )
+    pub fn _transfer(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<(), Erc20Error> {
+        // Decreasing sender balance
+        let mut sender_balance = self.balances.setter(from);
+        let old_sender_balance = sender_balance.get();
+        if old_sender_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from,
+                have: old_sender_balance,
+                want: value,
+            }));
+        }
+        sender_balance.set(old_sender_balance - value);
+
+        // Increasing receiver balance
+        let mut to_balance = self.balances.setter(to);
+        let new_to_balance = to_balance.get() + value;
+        to_balance.set(new_to_balance);
+
+        // Emitting the transfer event
+        evm::log(Transfer { from, to, value });
+        Ok(())
+    }
+
+    /// Mints `value` tokens to `address`
+    pub fn mint(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+        // Increasing balance
+        let mut balance = self.balances.setter(address);
+        let new_balance = balance.get() + value;
+        balance.set(new_balance);
+
+        // Increasing total supply
+        self.total_supply.set(self.total_supply.get() + value);
+
+        // Emitting the transfer event
+        evm::log(Transfer {
+            from: Address::ZERO,
+            to: address,
+            value,
+        });
+
+        Ok(())
+    }
+
+    /// Burns `value` tokens from `address`
+    pub fn burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+        // Decreasing balance
+        let mut balance = self.balances.setter(address);
+        let old_balance = balance.get();
+        if old_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from: address,
+                have: old_balance,
+                want: value,
+            }));
+        }
+        balance.set(old_balance - value);
+
+        // Decreasing the total supply
+        self.total_supply.set(self.total_supply.get() - value);
+
+        // Emitting the transfer event
+        evm::log(Transfer {
+            from: address,
+            to: Address::ZERO,
+            value,
+        });
+
+        Ok(())
+    }
+}
+
+// These methods are external to other contracts
+// Note: modifying storage will become much prettier soon
+#[external]
+impl<T: Erc20Params> Erc20<T> {
+    /// Immutable token name
+    pub fn name() -> String {
+        T::NAME.into()
+    }
+
+    /// Immutable token symbol
+    pub fn symbol() -> String {
+        T::SYMBOL.into()
+    }
+
+    /// Immutable token decimals
+    pub fn decimals() -> u8 {
+        T::DECIMALS
+    }
+
+    /// Balance of `address`
+    pub fn balance_of(&self, address: Address) -> U256 {
+        self.balances.get(address)
+    }
+
+    /// Transfers `value` tokens from msg::sender() to `to`
+    pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
+        self._transfer(msg::sender(), to, value)?;
+        Ok(true)
+    }
+
+    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
+    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
+        self.allowances.setter(msg::sender()).insert(spender, value);
+        evm::log(Approval {
+            owner: msg::sender(),
+            spender,
+            value,
+        });
+        true
+    }
+
+    /// Transfers `value` tokens from `from` to `to`
+    /// (msg::sender() must be able to spend at least `value` tokens from `from`)
+    pub fn transfer_from(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<bool, Erc20Error> {
+        // Check msg::sender() allowance
+        let mut sender_allowances = self.allowances.setter(from);
+        let mut allowance = sender_allowances.setter(msg::sender());
+        let old_allowance = allowance.get();
+        if old_allowance < value {
+            return Err(Erc20Error::InsufficientAllowance(InsufficientAllowance {
+                owner: from,
+                spender: msg::sender(),
+                have: old_allowance,
+                want: value,
+            }));
+        }
+
+        // Decreases allowance
+        allowance.set(old_allowance - value);
+
+        // Calls the internal transfer function
+        self._transfer(from, to, value)?;
+
+        Ok(true)
+    }
+
+    /// Returns the allowance of `spender` on `owner`'s tokens
+    pub fn allowance(&self, owner: Address, spender: Address) -> U256 {
+        self.allowances.getter(owner).get(spender)
+    }
+}

--- a/example_code/applications/erc20/src/lib.rs
+++ b/example_code/applications/erc20/src/lib.rs
@@ -17,10 +17,10 @@ use crate::erc20::{Erc20, Erc20Params, Erc20Error};
 static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
 
 /// Immutable definitions
-struct MyTokenParams;
-impl Erc20Params for MyTokenParams {
-    const NAME: &'static str = "MyToken";
-    const SYMBOL: &'static str = "MTK";
+struct StylusTokenParams;
+impl Erc20Params for StylusTokenParams {
+    const NAME: &'static str = "StylusToken";
+    const SYMBOL: &'static str = "STK";
     const DECIMALS: u8 = 18;
 }
 
@@ -29,16 +29,16 @@ impl Erc20Params for MyTokenParams {
 // storage slots and types.
 sol_storage! {
     #[entrypoint]
-    struct MyToken {
-        // Allows erc20 to access MyToken's storage and make calls
+    struct StylusToken {
+        // Allows erc20 to access StylusToken's storage and make calls
         #[borrow]
-        Erc20<MyTokenParams> erc20;
+        Erc20<StylusTokenParams> erc20;
     }
 }
 
 #[external]
-#[inherit(Erc20<MyTokenParams>)]
-impl MyToken {
+#[inherit(Erc20<StylusTokenParams>)]
+impl StylusToken {
     /// Mints tokens
     pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
         self.erc20.mint(to, value)?;

--- a/example_code/applications/erc20/src/lib.rs
+++ b/example_code/applications/erc20/src/lib.rs
@@ -1,0 +1,53 @@
+// Only run this as a WASM if the export-abi feature is not set.
+#![cfg_attr(not(any(feature = "export-abi", test)), no_main)]
+extern crate alloc;
+
+// Modules and imports
+mod erc20;
+
+use alloy_primitives::{Address, U256};
+use stylus_sdk::{
+    msg,
+    prelude::*
+};
+use crate::erc20::{Erc20, Erc20Params, Erc20Error};
+
+/// Initializes a custom, global allocator for Rust programs compiled to WASM.
+#[global_allocator]
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
+
+/// Immutable definitions
+struct MyTokenParams;
+impl Erc20Params for MyTokenParams {
+    const NAME: &'static str = "MyToken";
+    const SYMBOL: &'static str = "MTK";
+    const DECIMALS: u8 = 18;
+}
+
+// Define the entrypoint as a Solidity storage object. The sol_storage! macro
+// will generate Rust-equivalent structs with all fields mapped to Solidity-equivalent
+// storage slots and types.
+sol_storage! {
+    #[entrypoint]
+    struct MyToken {
+        // Allows erc20 to access MyToken's storage and make calls
+        #[borrow]
+        Erc20<MyTokenParams> erc20;
+    }
+}
+
+#[external]
+#[inherit(Erc20<MyTokenParams>)]
+impl MyToken {
+    /// Mints tokens
+    pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.mint(to, value)?;
+        Ok(())
+    }
+
+    /// Burns tokens
+    pub fn burn(&mut self, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.burn(msg::sender(), value)?;
+        Ok(())
+    }
+}

--- a/example_code/applications/erc20/src/lib.rs
+++ b/example_code/applications/erc20/src/lib.rs
@@ -40,7 +40,13 @@ sol_storage! {
 #[inherit(Erc20<StylusTokenParams>)]
 impl StylusToken {
     /// Mints tokens
-    pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
+    pub fn mint(&mut self, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.mint(msg::sender(), value)?;
+        Ok(())
+    }
+
+    /// Mints tokens to another address
+    pub fn mint_to(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
         self.erc20.mint(to, value)?;
         Ok(())
     }

--- a/example_code/applications/erc20/src/main.rs
+++ b/example_code/applications/erc20/src/main.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "export-abi")]
+fn main() {
+    stylus_erc20::print_abi("MIT-OR-APACHE-2.0", "pragma solidity ^0.8.23;");
+}

--- a/example_code/applications/erc721/Cargo.toml
+++ b/example_code/applications/erc721/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "stylus-erc721"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+stylus-sdk = "0.5.0"
+mini-alloc = "0.4.2"
+alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
+
+[features]
+export-abi = ["stylus-sdk/export-abi"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[profile.release]
+codegen-units = 1
+strip = true
+lto = true
+panic = "abort"
+opt-level = "s"

--- a/example_code/applications/erc721/src/erc721.rs
+++ b/example_code/applications/erc721/src/erc721.rs
@@ -9,7 +9,7 @@
 //! Note that this code is unaudited and not fit for production use.
 
 use alloc::{string::String, vec, vec::Vec};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, FixedBytes};
 use alloy_sol_types::sol;
 use core::{borrow::BorrowMut, marker::PhantomData};
 use stylus_sdk::{
@@ -36,11 +36,11 @@ sol_storage! {
         /// Token id to owner map
         mapping(uint256 => address) owners;
         /// User to balance map
-        mapping(address => uint256) balance;
+        mapping(address => uint256) balances;
         /// Token id to approved user map
-        mapping(uint256 => address) approved;
+        mapping(uint256 => address) token_approvals;
         /// User to operator map (the operator can manage all NFTs of the owner)
-        mapping(address => mapping(address => bool)) approved_for_all;
+        mapping(address => mapping(address => bool)) operator_approvals;
         /// Total supply
         uint256 total_supply;
         /// Used to allow [`Erc721Params`]
@@ -74,8 +74,18 @@ pub enum Erc721Error {
     NotApproved(NotApproved),
     TransferToZero(TransferToZero),
     ReceiverRefused(ReceiverRefused),
-    ExternalCall(stylus_sdk::call::Error),
 }
+
+// External interfaces
+sol_interface! {
+    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
+    interface IERC721TokenReceiver {
+        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
+    }
+}
+
+/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
+const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
 
 // These methods aren't external, but are helpers used by external methods.
 // Methods marked as "pub" here are usable outside of the erc721 module (i.e. they're callable from lib.rs).
@@ -98,12 +108,12 @@ impl<T: Erc721Params> Erc721<T> {
         }
 
         // caller is an operator for the owner (can manage their tokens)
-        if self.approved_for_all.getter(owner).get(msg::sender()) {
+        if self.operator_approvals.getter(owner).get(msg::sender()) {
             return Ok(());
         }
 
         // caller is approved to manage this token_id
-        if msg::sender() == self.approved.get(token_id) {
+        if msg::sender() == self.token_approvals.get(token_id) {
             return Ok(());
         }
 
@@ -131,15 +141,17 @@ impl<T: Erc721Params> Erc721<T> {
         owner.set(to);
 
         // right now working with storage can be verbose, but this will change upcoming version of the Stylus SDK
-        let mut from_balance = self.balance.setter(from);
+        let mut from_balance = self.balances.setter(from);
         let balance = from_balance.get() - U256::from(1);
         from_balance.set(balance);
 
-        let mut to_balance = self.balance.setter(to);
+        let mut to_balance = self.balances.setter(to);
         let balance = to_balance.get() + U256::from(1);
         to_balance.set(balance);
 
-        self.approved.delete(token_id);
+        // cleaning app the approved mapping for this token
+        self.token_approvals.delete(token_id);
+        
         evm::log(Transfer { from, to, token_id });
         Ok(())
     }
@@ -196,21 +208,12 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// Burns the token `token_id` from `from`
+    /// Note that total_supply is not reduced since it's used to calculate the next token_id to mint
     pub fn burn(&mut self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
         self.transfer(token_id, from, Address::default())?;
         Ok(())
     }
 }
-
-sol_interface! {
-    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
-    interface IERC721TokenReceiver {
-        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
-    }
-}
-
-/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
-const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
 
 // these methods are external to other contracts
 #[external]
@@ -226,28 +229,15 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// The NFT's Uniform Resource Identifier.
+    #[selector(name = "tokenURI")]
     pub fn token_uri(&self, token_id: U256) -> Result<String, Erc721Error> {
         self.owner_of(token_id)?; // require NFT exist
         Ok(T::token_uri(token_id))
     }
 
-    /// Whether the NFT supports a given standard.
-    pub fn supports_interface(interface: [u8; 4]) -> Result<bool, Erc721Error> {
-        if interface == [0xff; 4] {
-            // special cased in the ERC165 standard
-            return Ok(false);
-        }
-
-        const IERC165: u32 = 0x01ffc9a7;
-        const IERC721: u32 = 0x80ac58cd;
-        const _IERC721_ENUMERABLE: u32 = 0x780e9d63; // TODO: implement standard
-
-        Ok(matches!(u32::from_be_bytes(interface), IERC165 | IERC721))
-    }
-
     /// Gets the number of NFTs owned by an account.
     pub fn balance_of(&self, owner: Address) -> Result<U256, Erc721Error> {
-        Ok(self.balance.get(owner))
+        Ok(self.balances.get(owner))
     }
 
     /// Gets the owner of the NFT, if it exists.
@@ -260,20 +250,7 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// Transfers an NFT, but only after checking the `to` address can receive the NFT.
-    #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        from: Address,
-        to: Address,
-        token_id: U256,
-    ) -> Result<(), Erc721Error> {
-        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
-    }
-
-    /// Equivalent to [`safe_transfer_from`], but with additional data for the receiver.
-    ///
-    /// Note: because Rust doesn't allow multiple methods with the same name,
-    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    /// It includes additional data for the receiver.
     #[selector(name = "safeTransferFrom")]
     pub fn safe_transfer_from_with_data<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -292,6 +269,20 @@ impl<T: Erc721Params> Erc721<T> {
         Self::safe_transfer(storage, token_id, from, to, data.0)
     }
 
+    /// Equivalent to [`safe_transfer_from_with_data`], but without the additional data.
+    ///
+    /// Note: because Rust doesn't allow multiple methods with the same name,
+    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), Erc721Error> {
+        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
+    }
+
     /// Transfers the NFT.
     pub fn transfer_from(&mut self, from: Address, to: Address, token_id: U256) -> Result<(), Erc721Error> {
         if to.is_zero() {
@@ -307,14 +298,14 @@ impl<T: Erc721Params> Erc721<T> {
         let owner = self.owner_of(token_id)?;
 
         // require authorization
-        if msg::sender() != owner && !self.approved_for_all.getter(owner).get(msg::sender()) {
+        if msg::sender() != owner && !self.operator_approvals.getter(owner).get(msg::sender()) {
             return Err(Erc721Error::NotApproved(NotApproved {
                 owner,
                 spender: msg::sender(),
                 token_id,
             }));
         }
-        self.approved.insert(token_id, approved);
+        self.token_approvals.insert(token_id, approved);
 
         evm::log(Approval {
             approved,
@@ -327,7 +318,7 @@ impl<T: Erc721Params> Erc721<T> {
     /// Grants an account the ability to manage all of the sender's NFTs.
     pub fn set_approval_for_all(&mut self, operator: Address, approved: bool) -> Result<(), Erc721Error> {
         let owner = msg::sender();
-        self.approved_for_all
+        self.operator_approvals
             .setter(owner)
             .insert(operator, approved);
 
@@ -341,11 +332,27 @@ impl<T: Erc721Params> Erc721<T> {
 
     /// Gets the account managing an NFT, or zero if unmanaged.
     pub fn get_approved(&mut self, token_id: U256) -> Result<Address, Erc721Error> {
-        Ok(self.approved.get(token_id))
+        Ok(self.token_approvals.get(token_id))
     }
 
     /// Determines if an account has been authorized to managing all of a user's NFTs.
     pub fn is_approved_for_all(&mut self, owner: Address, operator: Address) -> Result<bool, Erc721Error> {
-        Ok(self.approved_for_all.getter(owner).get(operator))
+        Ok(self.operator_approvals.getter(owner).get(operator))
+    }
+
+    /// Whether the NFT supports a given standard.
+    pub fn supports_interface(interface: FixedBytes<4>) -> Result<bool, Erc721Error> {
+        let interface_slice_array: [u8; 4] = interface.as_slice().try_into().unwrap();
+
+        if u32::from_be_bytes(interface_slice_array) == 0xffffffff {
+            // special cased in the ERC165 standard
+            return Ok(false);
+        }
+
+        const IERC165: u32 = 0x01ffc9a7;
+        const IERC721: u32 = 0x80ac58cd;
+        const IERC721_METADATA: u32 = 0x5b5e139f;
+
+        Ok(matches!(u32::from_be_bytes(interface_slice_array), IERC165 | IERC721 | IERC721_METADATA))
     }
 }

--- a/example_code/applications/erc721/src/erc721.rs
+++ b/example_code/applications/erc721/src/erc721.rs
@@ -1,0 +1,346 @@
+//! Implementation of the ERC-721 standard
+//!
+//! The eponymous [`Erc721`] type provides all the standard methods,
+//! and is intended to be inherited by other contract types.
+//!
+//! You can configure the behavior of [`Erc721`] via the [`Erc721Params`] trait,
+//! which allows specifying the name, symbol, and token uri.
+//!
+//! Note that this code is unaudited and not fit for production use.
+
+use alloc::{string::String, vec, vec::Vec};
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::sol;
+use core::{borrow::BorrowMut, marker::PhantomData};
+use stylus_sdk::{
+    abi::Bytes,
+    evm,
+    msg,
+    prelude::*
+};
+
+pub trait Erc721Params {
+    /// Immutable NFT name.
+    const NAME: &'static str;
+
+    /// Immutable NFT symbol.
+    const SYMBOL: &'static str;
+
+    /// The NFT's Uniform Resource Identifier.
+    fn token_uri(token_id: U256) -> String;
+}
+
+sol_storage! {
+    /// Erc721 implements all ERC-721 methods
+    pub struct Erc721<T: Erc721Params> {
+        /// Token id to owner map
+        mapping(uint256 => address) owners;
+        /// User to balance map
+        mapping(address => uint256) balance;
+        /// Token id to approved user map
+        mapping(uint256 => address) approved;
+        /// User to operator map (the operator can manage all NFTs of the owner)
+        mapping(address => mapping(address => bool)) approved_for_all;
+        /// Total supply
+        uint256 total_supply;
+        /// Used to allow [`Erc721Params`]
+        PhantomData<T> phantom;
+    }
+}
+
+// Declare events and Solidity error types
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 indexed token_id);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed token_id);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    // Token id has not been minted, or it has been burned
+    error InvalidTokenId(uint256 token_id);
+    // The specified address is not the owner of the specified token id
+    error NotOwner(address from, uint256 token_id, address real_owner);
+    // The specified address does not have allowance to spend the specified token id
+    error NotApproved(address owner, address spender, uint256 token_id);
+    // Attempt to transfer token id to the Zero address
+    error TransferToZero(uint256 token_id);
+    // The receiver address refused to receive the specified token id
+    error ReceiverRefused(address receiver, uint256 token_id, bytes4 returned);
+}
+
+/// Represents the ways methods may fail.
+#[derive(SolidityError)]
+pub enum Erc721Error {
+    InvalidTokenId(InvalidTokenId),
+    NotOwner(NotOwner),
+    NotApproved(NotApproved),
+    TransferToZero(TransferToZero),
+    ReceiverRefused(ReceiverRefused),
+    ExternalCall(stylus_sdk::call::Error),
+}
+
+// These methods aren't external, but are helpers used by external methods.
+// Methods marked as "pub" here are usable outside of the erc721 module (i.e. they're callable from lib.rs).
+impl<T: Erc721Params> Erc721<T> {
+    /// Requires that msg::sender() is authorized to spend a given token
+    fn require_authorized_to_spend(&self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
+        // `from` must be the owner of the token_id
+        let owner = self.owner_of(token_id)?;
+        if from != owner {
+            return Err(Erc721Error::NotOwner(NotOwner {
+                from,
+                token_id,
+                real_owner: owner,
+            }));
+        }
+
+        // caller is the owner
+        if msg::sender() == owner {
+            return Ok(());
+        }
+
+        // caller is an operator for the owner (can manage their tokens)
+        if self.approved_for_all.getter(owner).get(msg::sender()) {
+            return Ok(());
+        }
+
+        // caller is approved to manage this token_id
+        if msg::sender() == self.approved.get(token_id) {
+            return Ok(());
+        }
+
+        // otherwise, caller is not allowed to manage this token_id
+        Err(Erc721Error::NotApproved(NotApproved {
+            owner,
+            spender: msg::sender(),
+            token_id,
+        }))
+    }
+
+    /// Transfers `token_id` from `from` to `to`.
+    /// This function does check that `from` is the owner of the token, but it does not check
+    /// that `to` is not the zero address, as this function is usable for burning.
+    pub fn transfer(&mut self, token_id: U256, from: Address, to: Address) -> Result<(), Erc721Error> {
+        let mut owner = self.owners.setter(token_id);
+        let previous_owner = owner.get();
+        if previous_owner != from {
+            return Err(Erc721Error::NotOwner(NotOwner {
+                from,
+                token_id,
+                real_owner: previous_owner,
+            }));
+        }
+        owner.set(to);
+
+        // right now working with storage can be verbose, but this will change upcoming version of the Stylus SDK
+        let mut from_balance = self.balance.setter(from);
+        let balance = from_balance.get() - U256::from(1);
+        from_balance.set(balance);
+
+        let mut to_balance = self.balance.setter(to);
+        let balance = to_balance.get() + U256::from(1);
+        to_balance.set(balance);
+
+        self.approved.delete(token_id);
+        evm::log(Transfer { from, to, token_id });
+        Ok(())
+    }
+
+    /// Calls `onERC721Received` on the `to` address if it is a contract.
+    /// Otherwise it does nothing
+    fn call_receiver<S: TopLevelStorage>(
+        storage: &mut S,
+        token_id: U256,
+        from: Address,
+        to: Address,
+        data: Vec<u8>,
+    ) -> Result<(), Erc721Error> {
+        if to.has_code() {
+            let receiver = IERC721TokenReceiver::new(to);
+            let received = receiver
+                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)?
+                .0;
+
+            if u32::from_be_bytes(received) != ERC721_TOKEN_RECEIVER_ID {
+                return Err(Erc721Error::ReceiverRefused(ReceiverRefused {
+                    receiver: receiver.address,
+                    token_id,
+                    returned: received,
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    /// Transfers and calls `onERC721Received`
+    pub fn safe_transfer<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        token_id: U256,
+        from: Address,
+        to: Address,
+        data: Vec<u8>,
+    ) -> Result<(), Erc721Error> {
+        storage.borrow_mut().transfer(token_id, from, to)?;
+        Self::call_receiver(storage, token_id, from, to, data)
+    }
+
+    /// Mints a new token and transfers it to `to`
+    pub fn mint(&mut self, to: Address) -> Result<(), Erc721Error> {
+        let new_token_id = self.total_supply.get();
+        self.total_supply.set(new_token_id + U256::from(1u8));
+        self.transfer(new_token_id, Address::default(), to)?;
+        Ok(())
+    }
+
+    /// Burns the token `token_id` from `from`
+    pub fn burn(&mut self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
+        self.transfer(token_id, from, Address::default())?;
+        Ok(())
+    }
+}
+
+sol_interface! {
+    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
+    interface IERC721TokenReceiver {
+        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
+    }
+}
+
+/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
+const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
+
+// these methods are external to other contracts
+#[external]
+impl<T: Erc721Params> Erc721<T> {
+    /// Immutable NFT name.
+    pub fn name() -> Result<String, Erc721Error> {
+        Ok(T::NAME.into())
+    }
+
+    /// Immutable NFT symbol.
+    pub fn symbol() -> Result<String, Erc721Error> {
+        Ok(T::SYMBOL.into())
+    }
+
+    /// The NFT's Uniform Resource Identifier.
+    pub fn token_uri(&self, token_id: U256) -> Result<String, Erc721Error> {
+        self.owner_of(token_id)?; // require NFT exist
+        Ok(T::token_uri(token_id))
+    }
+
+    /// Whether the NFT supports a given standard.
+    pub fn supports_interface(interface: [u8; 4]) -> Result<bool, Erc721Error> {
+        if interface == [0xff; 4] {
+            // special cased in the ERC165 standard
+            return Ok(false);
+        }
+
+        const IERC165: u32 = 0x01ffc9a7;
+        const IERC721: u32 = 0x80ac58cd;
+        const _IERC721_ENUMERABLE: u32 = 0x780e9d63; // TODO: implement standard
+
+        Ok(matches!(u32::from_be_bytes(interface), IERC165 | IERC721))
+    }
+
+    /// Gets the number of NFTs owned by an account.
+    pub fn balance_of(&self, owner: Address) -> Result<U256, Erc721Error> {
+        Ok(self.balance.get(owner))
+    }
+
+    /// Gets the owner of the NFT, if it exists.
+    pub fn owner_of(&self, token_id: U256) -> Result<Address, Erc721Error> {
+        let owner = self.owners.get(token_id);
+        if owner.is_zero() {
+            return Err(Erc721Error::InvalidTokenId(InvalidTokenId { token_id }));
+        }
+        Ok(owner)
+    }
+
+    /// Transfers an NFT, but only after checking the `to` address can receive the NFT.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), Erc721Error> {
+        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
+    }
+
+    /// Equivalent to [`safe_transfer_from`], but with additional data for the receiver.
+    ///
+    /// Note: because Rust doesn't allow multiple methods with the same name,
+    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from_with_data<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+        data: Bytes,
+    ) -> Result<(), Erc721Error> {
+        if to.is_zero() {
+            return Err(Erc721Error::TransferToZero(TransferToZero { token_id }));
+        }
+        storage
+            .borrow_mut()
+            .require_authorized_to_spend(from, token_id)?;
+
+        Self::safe_transfer(storage, token_id, from, to, data.0)
+    }
+
+    /// Transfers the NFT.
+    pub fn transfer_from(&mut self, from: Address, to: Address, token_id: U256) -> Result<(), Erc721Error> {
+        if to.is_zero() {
+            return Err(Erc721Error::TransferToZero(TransferToZero { token_id }));
+        }
+        self.require_authorized_to_spend(from, token_id)?;
+        self.transfer(token_id, from, to)?;
+        Ok(())
+    }
+
+    /// Grants an account the ability to manage the sender's NFT.
+    pub fn approve(&mut self, approved: Address, token_id: U256) -> Result<(), Erc721Error> {
+        let owner = self.owner_of(token_id)?;
+
+        // require authorization
+        if msg::sender() != owner && !self.approved_for_all.getter(owner).get(msg::sender()) {
+            return Err(Erc721Error::NotApproved(NotApproved {
+                owner,
+                spender: msg::sender(),
+                token_id,
+            }));
+        }
+        self.approved.insert(token_id, approved);
+
+        evm::log(Approval {
+            approved,
+            owner,
+            token_id,
+        });
+        Ok(())
+    }
+
+    /// Grants an account the ability to manage all of the sender's NFTs.
+    pub fn set_approval_for_all(&mut self, operator: Address, approved: bool) -> Result<(), Erc721Error> {
+        let owner = msg::sender();
+        self.approved_for_all
+            .setter(owner)
+            .insert(operator, approved);
+
+        evm::log(ApprovalForAll {
+            owner,
+            operator,
+            approved,
+        });
+        Ok(())
+    }
+
+    /// Gets the account managing an NFT, or zero if unmanaged.
+    pub fn get_approved(&mut self, token_id: U256) -> Result<Address, Erc721Error> {
+        Ok(self.approved.get(token_id))
+    }
+
+    /// Determines if an account has been authorized to managing all of a user's NFTs.
+    pub fn is_approved_for_all(&mut self, owner: Address, operator: Address) -> Result<bool, Erc721Error> {
+        Ok(self.approved_for_all.getter(owner).get(operator))
+    }
+}

--- a/example_code/applications/erc721/src/erc721.rs
+++ b/example_code/applications/erc721/src/erc721.rs
@@ -156,7 +156,12 @@ impl<T: Erc721Params> Erc721<T> {
         if to.has_code() {
             let receiver = IERC721TokenReceiver::new(to);
             let received = receiver
-                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)?
+                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)
+                .map_err(|_e| Erc721Error::ReceiverRefused(ReceiverRefused {
+                    receiver: receiver.address,
+                    token_id,
+                    returned: 0_u32.to_be_bytes(),
+                }))?
                 .0;
 
             if u32::from_be_bytes(received) != ERC721_TOKEN_RECEIVER_ID {

--- a/example_code/applications/erc721/src/lib.rs
+++ b/example_code/applications/erc721/src/lib.rs
@@ -1,0 +1,57 @@
+// Only run this as a WASM if the export-abi feature is not set.
+#![cfg_attr(not(any(feature = "export-abi", test)), no_main)]
+extern crate alloc;
+
+// Modules and imports
+mod erc721;
+
+use alloy_primitives::{U256};
+/// Import the Stylus SDK along with alloy primitive types for use in our program.
+use stylus_sdk::{
+    msg, prelude::*
+};
+use crate::erc721::{Erc721, Erc721Params, Erc721Error};
+
+/// Initializes a custom, global allocator for Rust programs compiled to WASM.
+#[global_allocator]
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
+
+/// Immutable definitions
+struct StylusNFTParams;
+impl Erc721Params for StylusNFTParams {
+    const NAME: &'static str = "StylusNFT";
+    const SYMBOL: &'static str = "SNFT";
+
+    fn token_uri(token_id: U256) -> String {
+        format!("{}{}{}", "https://my-nft-metadata.com/", token_id, ".json")
+    }
+}
+
+// Define the entrypoint as a Solidity storage object. The sol_storage! macro
+// will generate Rust-equivalent structs with all fields mapped to Solidity-equivalent
+// storage slots and types.
+sol_storage! {
+    #[entrypoint]
+    struct StylusNFT {
+        #[borrow] // Allows erc721 to access StylusNFT's storage and make calls
+        Erc721<StylusNFTParams> erc721;
+    }
+}
+
+#[external]
+#[inherit(Erc721<StylusNFTParams>)]
+impl StylusNFT {
+    /// Mints an NFT
+    pub fn mint(&mut self) -> Result<(), Erc721Error> {
+        let minter = msg::sender();
+        self.erc721.mint(minter)?;
+        Ok(())
+    }
+
+    /// Burns an NFT
+    pub fn burn(&mut self, token_id: U256) -> Result<(), Erc721Error> {
+        // This function checks that msg::sender() owns the specified token_id
+        self.erc721.burn(msg::sender(), token_id)?;
+        Ok(())
+    }
+}

--- a/example_code/applications/erc721/src/lib.rs
+++ b/example_code/applications/erc721/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 // Modules and imports
 mod erc721;
 
-use alloy_primitives::{U256};
+use alloy_primitives::{U256, Address};
 /// Import the Stylus SDK along with alloy primitive types for use in our program.
 use stylus_sdk::{
     msg, prelude::*
@@ -48,10 +48,21 @@ impl StylusNFT {
         Ok(())
     }
 
+    /// Mints an NFT to another address
+    pub fn mint_to(&mut self, to: Address) -> Result<(), Erc721Error> {
+        self.erc721.mint(to)?;
+        Ok(())
+    }
+
     /// Burns an NFT
     pub fn burn(&mut self, token_id: U256) -> Result<(), Erc721Error> {
         // This function checks that msg::sender() owns the specified token_id
         self.erc721.burn(msg::sender(), token_id)?;
         Ok(())
+    }
+
+    /// Total supply
+    pub fn total_supply(&mut self) -> Result<U256, Erc721Error> {
+        Ok(self.erc721.total_supply.get())
     }
 }

--- a/example_code/applications/erc721/src/main.rs
+++ b/example_code/applications/erc721/src/main.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "export-abi")]
+fn main() {
+    stylus_erc721::print_abi("MIT-OR-APACHE-2.0", "pragma solidity ^0.8.23;");
+}

--- a/src/app/applications/erc20/page.mdx
+++ b/src/app/applications/erc20/page.mdx
@@ -1,0 +1,349 @@
+export const metadata = {
+  title: "ERC-20 • Stylus by Example",
+  description:
+    "An example implementation of the ERC-20 token standard in Rust using Arbitrum Stylus.",
+};
+
+{/* Begin Content */}
+
+# ERC-20
+
+Any contract that follows the [ERC-20 standard](https://eips.ethereum.org/EIPS/eip-20) is an ERC-20 token.
+
+ERC-20 tokens provide functionalities to
+
+- transfer tokens
+- allow others to transfer tokens on behalf of the token holder
+
+Here is the interface for ERC-20.
+
+```solidity
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount)
+        external
+        returns (bool);
+}
+```
+
+Example implementation of an ERC-20 token contract written in Rust.
+
+### src/erc20.rs
+
+```rust
+//! Implementation of the ERC-20 standard
+//!
+//! The eponymous [`Erc20`] type provides all the standard methods,
+//! and is intended to be inherited by other contract types.
+//!
+//! You can configure the behavior of [`Erc20`] via the [`Erc20Params`] trait,
+//! which allows specifying the name, symbol, and decimals of the token.
+//!
+//! Note that this code is unaudited and not fit for production use.
+
+// Imported packages
+use alloc::string::String;
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::sol;
+use core::marker::PhantomData;
+use stylus_sdk::{
+    evm,
+    msg,
+    prelude::*,
+};
+
+pub trait Erc20Params {
+    /// Immutable token name
+    const NAME: &'static str;
+
+    /// Immutable token symbol
+    const SYMBOL: &'static str;
+
+    /// Immutable token decimals
+    const DECIMALS: u8;
+}
+
+sol_storage! {
+    /// Erc20 implements all ERC-20 methods.
+    pub struct Erc20<T> {
+        /// Maps users to balances
+        mapping(address => uint256) balances;
+        /// Maps users to a mapping of each spender's allowance
+        mapping(address => mapping(address => uint256)) allowances;
+        /// The total supply of the token
+        uint256 total_supply;
+        /// Used to allow [`Erc20Params`]
+        PhantomData<T> phantom;
+    }
+}
+
+// Declare events and Solidity error types
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error InsufficientBalance(address from, uint256 have, uint256 want);
+    error InsufficientAllowance(address owner, address spender, uint256 have, uint256 want);
+}
+
+/// Represents the ways methods may fail.
+#[derive(SolidityError)]
+pub enum Erc20Error {
+    InsufficientBalance(InsufficientBalance),
+    InsufficientAllowance(InsufficientAllowance),
+}
+
+// These methods aren't exposed to other contracts
+// Methods marked as "pub" here are usable outside of the erc20 module (i.e. they're callable from lib.rs)
+// Note: modifying storage will become much prettier soon
+impl<T: Erc20Params> Erc20<T> {
+    /// Movement of funds between 2 accounts
+    /// (invoked by the external transfer() and transfer_from() functions )
+    pub fn _transfer(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<(), Erc20Error> {
+        // Decreasing sender balance
+        let mut sender_balance = self.balances.setter(from);
+        let old_sender_balance = sender_balance.get();
+        if old_sender_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from,
+                have: old_sender_balance,
+                want: value,
+            }));
+        }
+        sender_balance.set(old_sender_balance - value);
+
+        // Increasing receiver balance
+        let mut to_balance = self.balances.setter(to);
+        let new_to_balance = to_balance.get() + value;
+        to_balance.set(new_to_balance);
+
+        // Emitting the transfer event
+        evm::log(Transfer { from, to, value });
+        Ok(())
+    }
+
+    /// Mints `value` tokens to `address`
+    pub fn mint(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+        // Increasing balance
+        let mut balance = self.balances.setter(address);
+        let new_balance = balance.get() + value;
+        balance.set(new_balance);
+
+        // Increasing total supply
+        self.total_supply.set(self.total_supply.get() + value);
+
+        // Emitting the transfer event
+        evm::log(Transfer {
+            from: Address::ZERO,
+            to: address,
+            value,
+        });
+
+        Ok(())
+    }
+
+    /// Burns `value` tokens from `address`
+    pub fn burn(&mut self, address: Address, value: U256) -> Result<(), Erc20Error> {
+        // Decreasing balance
+        let mut balance = self.balances.setter(address);
+        let old_balance = balance.get();
+        if old_balance < value {
+            return Err(Erc20Error::InsufficientBalance(InsufficientBalance {
+                from: address,
+                have: old_balance,
+                want: value,
+            }));
+        }
+        balance.set(old_balance - value);
+
+        // Decreasing the total supply
+        self.total_supply.set(self.total_supply.get() - value);
+
+        // Emitting the transfer event
+        evm::log(Transfer {
+            from: address,
+            to: Address::ZERO,
+            value,
+        });
+
+        Ok(())
+    }
+}
+
+// These methods are external to other contracts
+// Note: modifying storage will become much prettier soon
+#[external]
+impl<T: Erc20Params> Erc20<T> {
+    /// Immutable token name
+    pub fn name() -> String {
+        T::NAME.into()
+    }
+
+    /// Immutable token symbol
+    pub fn symbol() -> String {
+        T::SYMBOL.into()
+    }
+
+    /// Immutable token decimals
+    pub fn decimals() -> u8 {
+        T::DECIMALS
+    }
+
+    /// Balance of `address`
+    pub fn balance_of(&self, address: Address) -> U256 {
+        self.balances.get(address)
+    }
+
+    /// Transfers `value` tokens from msg::sender() to `to`
+    pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
+        self._transfer(msg::sender(), to, value)?;
+        Ok(true)
+    }
+
+    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
+    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
+        self.allowances.setter(msg::sender()).insert(spender, value);
+        evm::log(Approval {
+            owner: msg::sender(),
+            spender,
+            value,
+        });
+        true
+    }
+
+    /// Transfers `value` tokens from `from` to `to`
+    /// (msg::sender() must be able to spend at least `value` tokens from `from`)
+    pub fn transfer_from(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<bool, Erc20Error> {
+        // Check msg::sender() allowance
+        let mut sender_allowances = self.allowances.setter(from);
+        let mut allowance = sender_allowances.setter(msg::sender());
+        let old_allowance = allowance.get();
+        if old_allowance < value {
+            return Err(Erc20Error::InsufficientAllowance(InsufficientAllowance {
+                owner: from,
+                spender: msg::sender(),
+                have: old_allowance,
+                want: value,
+            }));
+        }
+
+        // Decreases allowance
+        allowance.set(old_allowance - value);
+
+        // Calls the internal transfer function
+        self._transfer(from, to, value)?;
+
+        Ok(true)
+    }
+
+    /// Returns the allowance of `spender` on `owner`'s tokens
+    pub fn allowance(&self, owner: Address, spender: Address) -> U256 {
+        self.allowances.getter(owner).get(spender)
+    }
+}
+```
+
+### lib.rs
+
+```rust
+// Only run this as a WASM if the export-abi feature is not set.
+#![cfg_attr(not(any(feature = "export-abi", test)), no_main)]
+extern crate alloc;
+
+// Modules and imports
+mod erc20;
+
+use alloy_primitives::{Address, U256};
+use stylus_sdk::{
+    msg,
+    prelude::*
+};
+use crate::erc20::{Erc20, Erc20Params, Erc20Error};
+
+/// Initializes a custom, global allocator for Rust programs compiled to WASM.
+#[global_allocator]
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
+
+/// Immutable definitions
+struct MyTokenParams;
+impl Erc20Params for MyTokenParams {
+    const NAME: &'static str = "MyToken";
+    const SYMBOL: &'static str = "MTK";
+    const DECIMALS: u8 = 18;
+}
+
+// Define the entrypoint as a Solidity storage object. The sol_storage! macro
+// will generate Rust-equivalent structs with all fields mapped to Solidity-equivalent
+// storage slots and types.
+sol_storage! {
+    #[entrypoint]
+    struct MyToken {
+        // Allows erc20 to access MyToken's storage and make calls
+        #[borrow]
+        Erc20<MyTokenParams> erc20;
+    }
+}
+
+#[external]
+#[inherit(Erc20<MyTokenParams>)]
+impl MyToken {
+    /// Mints tokens
+    pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.mint(to, value)?;
+        Ok(())
+    }
+
+    /// Burns tokens
+    pub fn burn(&mut self, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.burn(msg::sender(), value)?;
+        Ok(())
+    }
+}
+```
+
+### Cargo.toml
+
+```toml
+[package]
+name = "stylus-erc20"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+stylus-sdk = "0.5.0"
+mini-alloc = "0.4.2"
+alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
+
+[features]
+export-abi = ["stylus-sdk/export-abi"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[profile.release]
+codegen-units = 1
+strip = true
+lto = true
+panic = "abort"
+opt-level = "s"
+```

--- a/src/app/applications/erc20/page.mdx
+++ b/src/app/applications/erc20/page.mdx
@@ -203,26 +203,20 @@ impl<T: Erc20Params> Erc20<T> {
         T::DECIMALS
     }
 
+    /// Total supply of tokens
+    pub fn total_supply(&self) -> U256 {
+        self.total_supply.get()
+    }
+
     /// Balance of `address`
-    pub fn balance_of(&self, address: Address) -> U256 {
-        self.balances.get(address)
+    pub fn balance_of(&self, owner: Address) -> U256 {
+        self.balances.get(owner)
     }
 
     /// Transfers `value` tokens from msg::sender() to `to`
     pub fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Erc20Error> {
         self._transfer(msg::sender(), to, value)?;
         Ok(true)
-    }
-
-    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
-    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
-        self.allowances.setter(msg::sender()).insert(spender, value);
-        evm::log(Approval {
-            owner: msg::sender(),
-            spender,
-            value,
-        });
-        true
     }
 
     /// Transfers `value` tokens from `from` to `to`
@@ -253,6 +247,17 @@ impl<T: Erc20Params> Erc20<T> {
         self._transfer(from, to, value)?;
 
         Ok(true)
+    }
+
+    /// Approves the spenditure of `value` tokens of msg::sender() to `spender`
+    pub fn approve(&mut self, spender: Address, value: U256) -> bool {
+        self.allowances.setter(msg::sender()).insert(spender, value);
+        evm::log(Approval {
+            owner: msg::sender(),
+            spender,
+            value,
+        });
+        true
     }
 
     /// Returns the allowance of `spender` on `owner`'s tokens
@@ -307,7 +312,13 @@ sol_storage! {
 #[inherit(Erc20<StylusTokenParams>)]
 impl StylusToken {
     /// Mints tokens
-    pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
+    pub fn mint(&mut self, value: U256) -> Result<(), Erc20Error> {
+        self.erc20.mint(msg::sender(), value)?;
+        Ok(())
+    }
+
+    /// Mints tokens to another address
+    pub fn mint_to(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
         self.erc20.mint(to, value)?;
         Ok(())
     }

--- a/src/app/applications/erc20/page.mdx
+++ b/src/app/applications/erc20/page.mdx
@@ -284,10 +284,10 @@ use crate::erc20::{Erc20, Erc20Params, Erc20Error};
 static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
 
 /// Immutable definitions
-struct MyTokenParams;
-impl Erc20Params for MyTokenParams {
-    const NAME: &'static str = "MyToken";
-    const SYMBOL: &'static str = "MTK";
+struct StylusTokenParams;
+impl Erc20Params for StylusTokenParams {
+    const NAME: &'static str = "StylusToken";
+    const SYMBOL: &'static str = "STK";
     const DECIMALS: u8 = 18;
 }
 
@@ -296,16 +296,16 @@ impl Erc20Params for MyTokenParams {
 // storage slots and types.
 sol_storage! {
     #[entrypoint]
-    struct MyToken {
-        // Allows erc20 to access MyToken's storage and make calls
+    struct StylusToken {
+        // Allows erc20 to access StylusToken's storage and make calls
         #[borrow]
-        Erc20<MyTokenParams> erc20;
+        Erc20<StylusTokenParams> erc20;
     }
 }
 
 #[external]
-#[inherit(Erc20<MyTokenParams>)]
-impl MyToken {
+#[inherit(Erc20<StylusTokenParams>)]
+impl StylusToken {
     /// Mints tokens
     pub fn mint(&mut self, to: Address, value: U256) -> Result<(), Erc20Error> {
         self.erc20.mint(to, value)?;

--- a/src/app/applications/erc721/page.mdx
+++ b/src/app/applications/erc721/page.mdx
@@ -46,7 +46,7 @@ Example implementation of an ERC-721 token contract written in Rust.
 //! Note that this code is unaudited and not fit for production use.
 
 use alloc::{string::String, vec, vec::Vec};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, U256, FixedBytes};
 use alloy_sol_types::sol;
 use core::{borrow::BorrowMut, marker::PhantomData};
 use stylus_sdk::{
@@ -73,11 +73,11 @@ sol_storage! {
         /// Token id to owner map
         mapping(uint256 => address) owners;
         /// User to balance map
-        mapping(address => uint256) balance;
+        mapping(address => uint256) balances;
         /// Token id to approved user map
-        mapping(uint256 => address) approved;
+        mapping(uint256 => address) token_approvals;
         /// User to operator map (the operator can manage all NFTs of the owner)
-        mapping(address => mapping(address => bool)) approved_for_all;
+        mapping(address => mapping(address => bool)) operator_approvals;
         /// Total supply
         uint256 total_supply;
         /// Used to allow [`Erc721Params`]
@@ -111,8 +111,18 @@ pub enum Erc721Error {
     NotApproved(NotApproved),
     TransferToZero(TransferToZero),
     ReceiverRefused(ReceiverRefused),
-    ExternalCall(stylus_sdk::call::Error),
 }
+
+// External interfaces
+sol_interface! {
+    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
+    interface IERC721TokenReceiver {
+        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
+    }
+}
+
+/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
+const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
 
 // These methods aren't external, but are helpers used by external methods.
 // Methods marked as "pub" here are usable outside of the erc721 module (i.e. they're callable from lib.rs).
@@ -135,12 +145,12 @@ impl<T: Erc721Params> Erc721<T> {
         }
 
         // caller is an operator for the owner (can manage their tokens)
-        if self.approved_for_all.getter(owner).get(msg::sender()) {
+        if self.operator_approvals.getter(owner).get(msg::sender()) {
             return Ok(());
         }
 
         // caller is approved to manage this token_id
-        if msg::sender() == self.approved.get(token_id) {
+        if msg::sender() == self.token_approvals.get(token_id) {
             return Ok(());
         }
 
@@ -168,15 +178,17 @@ impl<T: Erc721Params> Erc721<T> {
         owner.set(to);
 
         // right now working with storage can be verbose, but this will change upcoming version of the Stylus SDK
-        let mut from_balance = self.balance.setter(from);
+        let mut from_balance = self.balances.setter(from);
         let balance = from_balance.get() - U256::from(1);
         from_balance.set(balance);
 
-        let mut to_balance = self.balance.setter(to);
+        let mut to_balance = self.balances.setter(to);
         let balance = to_balance.get() + U256::from(1);
         to_balance.set(balance);
 
-        self.approved.delete(token_id);
+        // cleaning app the approved mapping for this token
+        self.token_approvals.delete(token_id);
+        
         evm::log(Transfer { from, to, token_id });
         Ok(())
     }
@@ -233,21 +245,12 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// Burns the token `token_id` from `from`
+    /// Note that total_supply is not reduced since it's used to calculate the next token_id to mint
     pub fn burn(&mut self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
         self.transfer(token_id, from, Address::default())?;
         Ok(())
     }
 }
-
-sol_interface! {
-    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
-    interface IERC721TokenReceiver {
-        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
-    }
-}
-
-/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
-const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
 
 // these methods are external to other contracts
 #[external]
@@ -263,28 +266,15 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// The NFT's Uniform Resource Identifier.
+    #[selector(name = "tokenURI")]
     pub fn token_uri(&self, token_id: U256) -> Result<String, Erc721Error> {
         self.owner_of(token_id)?; // require NFT exist
         Ok(T::token_uri(token_id))
     }
 
-    /// Whether the NFT supports a given standard.
-    pub fn supports_interface(interface: [u8; 4]) -> Result<bool, Erc721Error> {
-        if interface == [0xff; 4] {
-            // special cased in the ERC165 standard
-            return Ok(false);
-        }
-
-        const IERC165: u32 = 0x01ffc9a7;
-        const IERC721: u32 = 0x80ac58cd;
-        const _IERC721_ENUMERABLE: u32 = 0x780e9d63; // TODO: implement standard
-
-        Ok(matches!(u32::from_be_bytes(interface), IERC165 | IERC721))
-    }
-
     /// Gets the number of NFTs owned by an account.
     pub fn balance_of(&self, owner: Address) -> Result<U256, Erc721Error> {
-        Ok(self.balance.get(owner))
+        Ok(self.balances.get(owner))
     }
 
     /// Gets the owner of the NFT, if it exists.
@@ -297,20 +287,7 @@ impl<T: Erc721Params> Erc721<T> {
     }
 
     /// Transfers an NFT, but only after checking the `to` address can receive the NFT.
-    #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
-        from: Address,
-        to: Address,
-        token_id: U256,
-    ) -> Result<(), Erc721Error> {
-        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
-    }
-
-    /// Equivalent to [`safe_transfer_from`], but with additional data for the receiver.
-    ///
-    /// Note: because Rust doesn't allow multiple methods with the same name,
-    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    /// It includes additional data for the receiver.
     #[selector(name = "safeTransferFrom")]
     pub fn safe_transfer_from_with_data<S: TopLevelStorage + BorrowMut<Self>>(
         storage: &mut S,
@@ -329,6 +306,20 @@ impl<T: Erc721Params> Erc721<T> {
         Self::safe_transfer(storage, token_id, from, to, data.0)
     }
 
+    /// Equivalent to [`safe_transfer_from_with_data`], but without the additional data.
+    ///
+    /// Note: because Rust doesn't allow multiple methods with the same name,
+    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), Erc721Error> {
+        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
+    }
+
     /// Transfers the NFT.
     pub fn transfer_from(&mut self, from: Address, to: Address, token_id: U256) -> Result<(), Erc721Error> {
         if to.is_zero() {
@@ -344,14 +335,14 @@ impl<T: Erc721Params> Erc721<T> {
         let owner = self.owner_of(token_id)?;
 
         // require authorization
-        if msg::sender() != owner && !self.approved_for_all.getter(owner).get(msg::sender()) {
+        if msg::sender() != owner && !self.operator_approvals.getter(owner).get(msg::sender()) {
             return Err(Erc721Error::NotApproved(NotApproved {
                 owner,
                 spender: msg::sender(),
                 token_id,
             }));
         }
-        self.approved.insert(token_id, approved);
+        self.token_approvals.insert(token_id, approved);
 
         evm::log(Approval {
             approved,
@@ -364,7 +355,7 @@ impl<T: Erc721Params> Erc721<T> {
     /// Grants an account the ability to manage all of the sender's NFTs.
     pub fn set_approval_for_all(&mut self, operator: Address, approved: bool) -> Result<(), Erc721Error> {
         let owner = msg::sender();
-        self.approved_for_all
+        self.operator_approvals
             .setter(owner)
             .insert(operator, approved);
 
@@ -378,12 +369,28 @@ impl<T: Erc721Params> Erc721<T> {
 
     /// Gets the account managing an NFT, or zero if unmanaged.
     pub fn get_approved(&mut self, token_id: U256) -> Result<Address, Erc721Error> {
-        Ok(self.approved.get(token_id))
+        Ok(self.token_approvals.get(token_id))
     }
 
     /// Determines if an account has been authorized to managing all of a user's NFTs.
     pub fn is_approved_for_all(&mut self, owner: Address, operator: Address) -> Result<bool, Erc721Error> {
-        Ok(self.approved_for_all.getter(owner).get(operator))
+        Ok(self.operator_approvals.getter(owner).get(operator))
+    }
+
+    /// Whether the NFT supports a given standard.
+    pub fn supports_interface(interface: FixedBytes<4>) -> Result<bool, Erc721Error> {
+        let interface_slice_array: [u8; 4] = interface.as_slice().try_into().unwrap();
+
+        if u32::from_be_bytes(interface_slice_array) == 0xffffffff {
+            // special cased in the ERC165 standard
+            return Ok(false);
+        }
+
+        const IERC165: u32 = 0x01ffc9a7;
+        const IERC721: u32 = 0x80ac58cd;
+        const IERC721_METADATA: u32 = 0x5b5e139f;
+
+        Ok(matches!(u32::from_be_bytes(interface_slice_array), IERC165 | IERC721 | IERC721_METADATA))
     }
 }
 ```
@@ -398,7 +405,7 @@ extern crate alloc;
 // Modules and imports
 mod erc721;
 
-use alloy_primitives::{U256};
+use alloy_primitives::{U256, Address};
 /// Import the Stylus SDK along with alloy primitive types for use in our program.
 use stylus_sdk::{
     msg, prelude::*
@@ -441,11 +448,22 @@ impl StylusNFT {
         Ok(())
     }
 
+    /// Mints an NFT to another address
+    pub fn mint_to(&mut self, to: Address) -> Result<(), Erc721Error> {
+        self.erc721.mint(to)?;
+        Ok(())
+    }
+
     /// Burns an NFT
     pub fn burn(&mut self, token_id: U256) -> Result<(), Erc721Error> {
         // This function checks that msg::sender() owns the specified token_id
         self.erc721.burn(msg::sender(), token_id)?;
         Ok(())
+    }
+
+    /// Total supply
+    pub fn total_supply(&mut self) -> Result<U256, Erc721Error> {
+        Ok(self.erc721.total_supply.get())
     }
 }
 ```
@@ -457,6 +475,7 @@ impl StylusNFT {
 name = "stylus-erc721"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 stylus-sdk = "0.5.0"

--- a/src/app/applications/erc721/page.mdx
+++ b/src/app/applications/erc721/page.mdx
@@ -1,0 +1,474 @@
+export const metadata = {
+  title: "ERC-721 • Stylus by Example",
+  description:
+    "An example implementation of the ERC-721 token standard in Rust using Arbitrum Stylus.",
+};
+
+{/* Begin Content */}
+
+# ERC-721
+
+Any contract that follows the [ERC-721 standard](https://eips.ethereum.org/EIPS/eip-721) is an ERC-721 token.
+
+Here is the interface for ERC-721.
+
+```solidity
+interface ERC721 {
+    event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    function balanceOf(address _owner) external view returns (uint256);
+    function ownerOf(uint256 _tokenId) external view returns (address);
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+    function approve(address _approved, uint256 _tokenId) external payable;
+    function setApprovalForAll(address _operator, bool _approved) external;
+    function getApproved(uint256 _tokenId) external view returns (address);
+    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+}
+```
+
+Example implementation of an ERC-721 token contract written in Rust.
+
+### src/erc721.rs
+
+```rust
+//! Implementation of the ERC-721 standard
+//!
+//! The eponymous [`Erc721`] type provides all the standard methods,
+//! and is intended to be inherited by other contract types.
+//!
+//! You can configure the behavior of [`Erc721`] via the [`Erc721Params`] trait,
+//! which allows specifying the name, symbol, and token uri.
+//!
+//! Note that this code is unaudited and not fit for production use.
+
+use alloc::{string::String, vec, vec::Vec};
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::sol;
+use core::{borrow::BorrowMut, marker::PhantomData};
+use stylus_sdk::{
+    abi::Bytes,
+    evm,
+    msg,
+    prelude::*
+};
+
+pub trait Erc721Params {
+    /// Immutable NFT name.
+    const NAME: &'static str;
+
+    /// Immutable NFT symbol.
+    const SYMBOL: &'static str;
+
+    /// The NFT's Uniform Resource Identifier.
+    fn token_uri(token_id: U256) -> String;
+}
+
+sol_storage! {
+    /// Erc721 implements all ERC-721 methods
+    pub struct Erc721<T: Erc721Params> {
+        /// Token id to owner map
+        mapping(uint256 => address) owners;
+        /// User to balance map
+        mapping(address => uint256) balance;
+        /// Token id to approved user map
+        mapping(uint256 => address) approved;
+        /// User to operator map (the operator can manage all NFTs of the owner)
+        mapping(address => mapping(address => bool)) approved_for_all;
+        /// Total supply
+        uint256 total_supply;
+        /// Used to allow [`Erc721Params`]
+        PhantomData<T> phantom;
+    }
+}
+
+// Declare events and Solidity error types
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 indexed token_id);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed token_id);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    // Token id has not been minted, or it has been burned
+    error InvalidTokenId(uint256 token_id);
+    // The specified address is not the owner of the specified token id
+    error NotOwner(address from, uint256 token_id, address real_owner);
+    // The specified address does not have allowance to spend the specified token id
+    error NotApproved(address owner, address spender, uint256 token_id);
+    // Attempt to transfer token id to the Zero address
+    error TransferToZero(uint256 token_id);
+    // The receiver address refused to receive the specified token id
+    error ReceiverRefused(address receiver, uint256 token_id, bytes4 returned);
+}
+
+/// Represents the ways methods may fail.
+#[derive(SolidityError)]
+pub enum Erc721Error {
+    InvalidTokenId(InvalidTokenId),
+    NotOwner(NotOwner),
+    NotApproved(NotApproved),
+    TransferToZero(TransferToZero),
+    ReceiverRefused(ReceiverRefused),
+    ExternalCall(stylus_sdk::call::Error),
+}
+
+// These methods aren't external, but are helpers used by external methods.
+// Methods marked as "pub" here are usable outside of the erc721 module (i.e. they're callable from lib.rs).
+impl<T: Erc721Params> Erc721<T> {
+    /// Requires that msg::sender() is authorized to spend a given token
+    fn require_authorized_to_spend(&self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
+        // `from` must be the owner of the token_id
+        let owner = self.owner_of(token_id)?;
+        if from != owner {
+            return Err(Erc721Error::NotOwner(NotOwner {
+                from,
+                token_id,
+                real_owner: owner,
+            }));
+        }
+
+        // caller is the owner
+        if msg::sender() == owner {
+            return Ok(());
+        }
+
+        // caller is an operator for the owner (can manage their tokens)
+        if self.approved_for_all.getter(owner).get(msg::sender()) {
+            return Ok(());
+        }
+
+        // caller is approved to manage this token_id
+        if msg::sender() == self.approved.get(token_id) {
+            return Ok(());
+        }
+
+        // otherwise, caller is not allowed to manage this token_id
+        Err(Erc721Error::NotApproved(NotApproved {
+            owner,
+            spender: msg::sender(),
+            token_id,
+        }))
+    }
+
+    /// Transfers `token_id` from `from` to `to`.
+    /// This function does check that `from` is the owner of the token, but it does not check
+    /// that `to` is not the zero address, as this function is usable for burning.
+    pub fn transfer(&mut self, token_id: U256, from: Address, to: Address) -> Result<(), Erc721Error> {
+        let mut owner = self.owners.setter(token_id);
+        let previous_owner = owner.get();
+        if previous_owner != from {
+            return Err(Erc721Error::NotOwner(NotOwner {
+                from,
+                token_id,
+                real_owner: previous_owner,
+            }));
+        }
+        owner.set(to);
+
+        // right now working with storage can be verbose, but this will change upcoming version of the Stylus SDK
+        let mut from_balance = self.balance.setter(from);
+        let balance = from_balance.get() - U256::from(1);
+        from_balance.set(balance);
+
+        let mut to_balance = self.balance.setter(to);
+        let balance = to_balance.get() + U256::from(1);
+        to_balance.set(balance);
+
+        self.approved.delete(token_id);
+        evm::log(Transfer { from, to, token_id });
+        Ok(())
+    }
+
+    /// Calls `onERC721Received` on the `to` address if it is a contract.
+    /// Otherwise it does nothing
+    fn call_receiver<S: TopLevelStorage>(
+        storage: &mut S,
+        token_id: U256,
+        from: Address,
+        to: Address,
+        data: Vec<u8>,
+    ) -> Result<(), Erc721Error> {
+        if to.has_code() {
+            let receiver = IERC721TokenReceiver::new(to);
+            let received = receiver
+                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)?
+                .0;
+
+            if u32::from_be_bytes(received) != ERC721_TOKEN_RECEIVER_ID {
+                return Err(Erc721Error::ReceiverRefused(ReceiverRefused {
+                    receiver: receiver.address,
+                    token_id,
+                    returned: received,
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    /// Transfers and calls `onERC721Received`
+    pub fn safe_transfer<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        token_id: U256,
+        from: Address,
+        to: Address,
+        data: Vec<u8>,
+    ) -> Result<(), Erc721Error> {
+        storage.borrow_mut().transfer(token_id, from, to)?;
+        Self::call_receiver(storage, token_id, from, to, data)
+    }
+
+    /// Mints a new token and transfers it to `to`
+    pub fn mint(&mut self, to: Address) -> Result<(), Erc721Error> {
+        let new_token_id = self.total_supply.get();
+        self.total_supply.set(new_token_id + U256::from(1u8));
+        self.transfer(new_token_id, Address::default(), to)?;
+        Ok(())
+    }
+
+    /// Burns the token `token_id` from `from`
+    pub fn burn(&mut self, from: Address, token_id: U256) -> Result<(), Erc721Error> {
+        self.transfer(token_id, from, Address::default())?;
+        Ok(())
+    }
+}
+
+sol_interface! {
+    /// Allows calls to the `onERC721Received` method of other contracts implementing `IERC721TokenReceiver`.
+    interface IERC721TokenReceiver {
+        function onERC721Received(address operator, address from, uint256 token_id, bytes data) external returns(bytes4);
+    }
+}
+
+/// Selector for `onERC721Received`, which is returned by contracts implementing `IERC721TokenReceiver`.
+const ERC721_TOKEN_RECEIVER_ID: u32 = 0x150b7a02;
+
+// these methods are external to other contracts
+#[external]
+impl<T: Erc721Params> Erc721<T> {
+    /// Immutable NFT name.
+    pub fn name() -> Result<String, Erc721Error> {
+        Ok(T::NAME.into())
+    }
+
+    /// Immutable NFT symbol.
+    pub fn symbol() -> Result<String, Erc721Error> {
+        Ok(T::SYMBOL.into())
+    }
+
+    /// The NFT's Uniform Resource Identifier.
+    pub fn token_uri(&self, token_id: U256) -> Result<String, Erc721Error> {
+        self.owner_of(token_id)?; // require NFT exist
+        Ok(T::token_uri(token_id))
+    }
+
+    /// Whether the NFT supports a given standard.
+    pub fn supports_interface(interface: [u8; 4]) -> Result<bool, Erc721Error> {
+        if interface == [0xff; 4] {
+            // special cased in the ERC165 standard
+            return Ok(false);
+        }
+
+        const IERC165: u32 = 0x01ffc9a7;
+        const IERC721: u32 = 0x80ac58cd;
+        const _IERC721_ENUMERABLE: u32 = 0x780e9d63; // TODO: implement standard
+
+        Ok(matches!(u32::from_be_bytes(interface), IERC165 | IERC721))
+    }
+
+    /// Gets the number of NFTs owned by an account.
+    pub fn balance_of(&self, owner: Address) -> Result<U256, Erc721Error> {
+        Ok(self.balance.get(owner))
+    }
+
+    /// Gets the owner of the NFT, if it exists.
+    pub fn owner_of(&self, token_id: U256) -> Result<Address, Erc721Error> {
+        let owner = self.owners.get(token_id);
+        if owner.is_zero() {
+            return Err(Erc721Error::InvalidTokenId(InvalidTokenId { token_id }));
+        }
+        Ok(owner)
+    }
+
+    /// Transfers an NFT, but only after checking the `to` address can receive the NFT.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), Erc721Error> {
+        Self::safe_transfer_from_with_data(storage, from, to, token_id, Bytes(vec![]))
+    }
+
+    /// Equivalent to [`safe_transfer_from`], but with additional data for the receiver.
+    ///
+    /// Note: because Rust doesn't allow multiple methods with the same name,
+    /// we use the `#[selector]` macro attribute to simulate solidity overloading.
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from_with_data<S: TopLevelStorage + BorrowMut<Self>>(
+        storage: &mut S,
+        from: Address,
+        to: Address,
+        token_id: U256,
+        data: Bytes,
+    ) -> Result<(), Erc721Error> {
+        if to.is_zero() {
+            return Err(Erc721Error::TransferToZero(TransferToZero { token_id }));
+        }
+        storage
+            .borrow_mut()
+            .require_authorized_to_spend(from, token_id)?;
+
+        Self::safe_transfer(storage, token_id, from, to, data.0)
+    }
+
+    /// Transfers the NFT.
+    pub fn transfer_from(&mut self, from: Address, to: Address, token_id: U256) -> Result<(), Erc721Error> {
+        if to.is_zero() {
+            return Err(Erc721Error::TransferToZero(TransferToZero { token_id }));
+        }
+        self.require_authorized_to_spend(from, token_id)?;
+        self.transfer(token_id, from, to)?;
+        Ok(())
+    }
+
+    /// Grants an account the ability to manage the sender's NFT.
+    pub fn approve(&mut self, approved: Address, token_id: U256) -> Result<(), Erc721Error> {
+        let owner = self.owner_of(token_id)?;
+
+        // require authorization
+        if msg::sender() != owner && !self.approved_for_all.getter(owner).get(msg::sender()) {
+            return Err(Erc721Error::NotApproved(NotApproved {
+                owner,
+                spender: msg::sender(),
+                token_id,
+            }));
+        }
+        self.approved.insert(token_id, approved);
+
+        evm::log(Approval {
+            approved,
+            owner,
+            token_id,
+        });
+        Ok(())
+    }
+
+    /// Grants an account the ability to manage all of the sender's NFTs.
+    pub fn set_approval_for_all(&mut self, operator: Address, approved: bool) -> Result<(), Erc721Error> {
+        let owner = msg::sender();
+        self.approved_for_all
+            .setter(owner)
+            .insert(operator, approved);
+
+        evm::log(ApprovalForAll {
+            owner,
+            operator,
+            approved,
+        });
+        Ok(())
+    }
+
+    /// Gets the account managing an NFT, or zero if unmanaged.
+    pub fn get_approved(&mut self, token_id: U256) -> Result<Address, Erc721Error> {
+        Ok(self.approved.get(token_id))
+    }
+
+    /// Determines if an account has been authorized to managing all of a user's NFTs.
+    pub fn is_approved_for_all(&mut self, owner: Address, operator: Address) -> Result<bool, Erc721Error> {
+        Ok(self.approved_for_all.getter(owner).get(operator))
+    }
+}
+```
+
+### lib.rs
+
+```rust
+// Only run this as a WASM if the export-abi feature is not set.
+#![cfg_attr(not(any(feature = "export-abi", test)), no_main)]
+extern crate alloc;
+
+// Modules and imports
+mod erc721;
+
+use alloy_primitives::{U256};
+/// Import the Stylus SDK along with alloy primitive types for use in our program.
+use stylus_sdk::{
+    msg, prelude::*
+};
+use crate::erc721::{Erc721, Erc721Params, Erc721Error};
+
+/// Initializes a custom, global allocator for Rust programs compiled to WASM.
+#[global_allocator]
+static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
+
+/// Immutable definitions
+struct StylusNFTParams;
+impl Erc721Params for StylusNFTParams {
+    const NAME: &'static str = "StylusNFT";
+    const SYMBOL: &'static str = "SNFT";
+
+    fn token_uri(token_id: U256) -> String {
+        format!("{}{}{}", "https://my-nft-metadata.com/", token_id, ".json")
+    }
+}
+
+// Define the entrypoint as a Solidity storage object. The sol_storage! macro
+// will generate Rust-equivalent structs with all fields mapped to Solidity-equivalent
+// storage slots and types.
+sol_storage! {
+    #[entrypoint]
+    struct StylusNFT {
+        #[borrow] // Allows erc721 to access StylusNFT's storage and make calls
+        Erc721<StylusNFTParams> erc721;
+    }
+}
+
+#[external]
+#[inherit(Erc721<StylusNFTParams>)]
+impl StylusNFT {
+    /// Mints an NFT
+    pub fn mint(&mut self) -> Result<(), Erc721Error> {
+        let minter = msg::sender();
+        self.erc721.mint(minter)?;
+        Ok(())
+    }
+
+    /// Burns an NFT
+    pub fn burn(&mut self, token_id: U256) -> Result<(), Erc721Error> {
+        // This function checks that msg::sender() owns the specified token_id
+        self.erc721.burn(msg::sender(), token_id)?;
+        Ok(())
+    }
+}
+```
+
+### Cargo.toml
+
+```toml
+[package]
+name = "stylus-erc721"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+stylus-sdk = "0.5.0"
+mini-alloc = "0.4.2"
+alloy-primitives = "0.3.1"
+alloy-sol-types = "0.3.1"
+
+[features]
+export-abi = ["stylus-sdk/export-abi"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[profile.release]
+codegen-units = 1
+strip = true
+lto = true
+panic = "abort"
+opt-level = "s"
+```

--- a/src/app/applications/erc721/page.mdx
+++ b/src/app/applications/erc721/page.mdx
@@ -193,7 +193,12 @@ impl<T: Erc721Params> Erc721<T> {
         if to.has_code() {
             let receiver = IERC721TokenReceiver::new(to);
             let received = receiver
-                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)?
+                .on_erc_721_received(&mut *storage, msg::sender(), from, token_id, data)
+                .map_err(|_e| Erc721Error::ReceiverRefused(ReceiverRefused {
+                    receiver: receiver.address,
+                    token_id,
+                    returned: 0_u32.to_be_bytes(),
+                }))?
                 .0;
 
             if u32::from_be_bytes(received) != ERC721_TOKEN_RECEIVER_ID {

--- a/src/app/applications/layout.tsx
+++ b/src/app/applications/layout.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from "next";
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export const metadata: Metadata = {
+  title: "Applications • Stylus by Example",
+  description:
+    "An introduction to Arbitrum Stylus with simple code examples in Rust and WASM",
+};
+
+export default function PageLayout({ children }: LayoutProps) {
+  return <>{children}</>;
+}

--- a/src/app/applications/page.tsx
+++ b/src/app/applications/page.tsx
@@ -1,0 +1,13 @@
+import { grid } from "@/styled-system/patterns";
+import { PageCard } from "@/components/app/page_card";
+import { applications } from "@/data/routes";
+
+export default function PageRoot() {
+  return (
+    <div className={grid({ columns: 2, gap: "6" })}>
+      {applications.map((routeInfo) => (
+        <PageCard {...routeInfo} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/app/navigation.tsx
+++ b/src/components/app/navigation.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 import { HamburgerMenuIcon } from "@radix-ui/react-icons";
-import { basicExamples, gettingStarted } from "@/data/routes";
+import { gettingStarted, basicExamples, applications  } from "@/data/routes";
 import { Stack } from "@/styled-system/jsx";
 import { css } from "@/styled-system/css";
 import { flex, hstack, stack } from "@/styled-system/patterns";
@@ -193,6 +193,37 @@ export default function Navigation() {
               </h2>
               <Stack gap={1}>
                 {basicExamples?.map(({ route, title }, i) => (
+                  <Button
+                    asChild
+                    key={`${title}-${i}`}
+                    variant="link"
+                    size="lg"
+                    className={css({
+                      w: "full",
+                      justifyContent: "flex-start",
+                      fontWeight: "normal",
+                      h: "32px",
+                      paddingInline: "16px",
+                    })}
+                  >
+                    <SheetClose asChild>
+                      <Link href={route}>{title}</Link>
+                    </SheetClose>
+                  </Button>
+                ))}
+              </Stack>
+              <h2
+                className={css({
+                  fontSize: "lg",
+                  fontWeight: "bold",
+                  mb: "1",
+                  px: "4",
+                })}
+              >
+                Applications
+              </h2>
+              <Stack gap={1}>
+                {applications?.map(({ route, title }, i) => (
                   <Button
                     asChild
                     key={`${title}-${i}`}

--- a/src/components/app/sidebar.tsx
+++ b/src/components/app/sidebar.tsx
@@ -1,4 +1,4 @@
-import { gettingStarted, basicExamples } from "@/data/routes";
+import { gettingStarted, basicExamples, applications } from "@/data/routes";
 import { css } from "@/styled-system/css";
 import { stack } from "@/styled-system/patterns";
 import { Stack } from "@/styled-system/jsx";
@@ -39,6 +39,10 @@ export function Sidebar() {
       <SidebarHeading>Basic</SidebarHeading>
       <Stack gap={1} mb={4}>
         <SidebarLinks routes={basicExamples} />
+      </Stack>
+      <SidebarHeading>Applications</SidebarHeading>
+      <Stack gap={1} mb={4}>
+        <SidebarLinks routes={applications} />
       </Stack>
     </div>
   );

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -52,3 +52,16 @@ export const basicExamples = [
     description: "Log public events to the blockchain",
   },
 ];
+
+export const applications = [
+  {
+    route: "/applications/erc20",
+    title: "ERC-20",
+    description: "An example implementation of the ERC-20 token standard in Rust",
+  },
+  {
+    route: "/applications/erc721",
+    title: "ERC-721",
+    description: "An example implementation of the ERC-721 token standard in Rust",
+  },
+];


### PR DESCRIPTION
This PR adds an ERC-20 and an ERC-721 example in a new Applications section, following the same structure as in [Solidity by example](https://solidity-by-example.org/app/erc20/).

~Pending performing a full set of tests with the contracts~
Ready