### PR TITLE
Fix dead link in Nitro dev node documentation

### DIFF
--- a/src/app/getting_started/using_the_cli/page.mdx
+++ b/src/app/getting_started/using_the_cli/page.mdx
@@ -17,7 +17,7 @@ In this example, we'll cover a typical workflow for deploying a Rust smart contr
 - [Cargo Stylus](https://github.com/OffchainLabs/cargo-stylus)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/)
-- [Local Stylus Dev Node](https://docs.arbitrum.io/stylus/how-tos/local-stylus-dev-node) (up and running)
+- [Local Stylus Dev Node](https://docs.arbitrum.io/run-arbitrum-node/run-nitro-dev-node) (up and running)
 
 ## Deploying and Testing the Counter Contract
 


### PR DESCRIPTION
Updated the URL to point to the correct resource. This resolves a broken link that could confuse developers referencing the documentation.